### PR TITLE
Improved connection reset after parallel tasks

### DIFF
--- a/lib/turbo-sprockets/railtie.rb
+++ b/lib/turbo-sprockets/railtie.rb
@@ -28,9 +28,7 @@ module TurboSprockets
 
         # for some reason parallel operations may cause activerecord to
         # disconnect
-        if const_defined?(:ActiveRecord)
-          ActiveRecord::Base.connection.reconnect!
-        end
+        ::ActiveRecord::Base.clear_active_connections!
       end
     end
   end


### PR DESCRIPTION
Using `reconnect!` assumes that the connection is still valid. ActiveRecord will attempt to execute queries against that connection, and crash here because there is no error handling.

Specifically, we were experiencing uncaught `PG::UnableToSend` errors generated by this line, because ActiveRecord attempts to dealloc items as part of the `reconnect!` process.