### PR TITLE
Restore guard on reconnecting db connections

### DIFF
--- a/lib/turbo-sprockets/railtie.rb
+++ b/lib/turbo-sprockets/railtie.rb
@@ -28,7 +28,7 @@ module TurboSprockets
 
         # for some reason parallel operations may cause activerecord to
         # disconnect
-        ::ActiveRecord::Base.clear_active_connections!
+        ::ActiveRecord::Base.clear_active_connections! if const_defined?(:ActiveRecord)
       end
     end
   end


### PR DESCRIPTION
This guard was removed in #2 but should stay.